### PR TITLE
Add toolbar and unit creation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -14,3 +14,36 @@
   min-height: 50px;
   box-sizing: border-box;
 }
+
+.toolbar {
+  text-align: center;
+  margin: 10px 0;
+}
+
+.toolbar button {
+  margin-right: 6px;
+  padding: 6px 12px;
+}
+
+.unit {
+  position: absolute;
+  border: 2px solid #333;
+  color: #fff;
+  font-size: 0.9em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+}
+
+.unit.cabinet {
+  background-color: #8b4513;
+}
+
+.unit.drawer {
+  background-color: #708090;
+}
+
+.unit.shelf {
+  background-color: #228b22;
+}

--- a/index.html
+++ b/index.html
@@ -9,6 +9,12 @@
 <body>
   <h1>Kitchen Sorter</h1>
 
+  <div id="unit-toolbar" class="toolbar">
+    <button data-unit="cabinet">Cabinet</button>
+    <button data-unit="drawer">Drawer</button>
+    <button data-unit="shelf">Shelf</button>
+  </div>
+
   <div id="grid-root"></div>
 
   <script src="js/main.js" defer></script>

--- a/js/grid.js
+++ b/js/grid.js
@@ -1,6 +1,14 @@
 (function() {
   const rows = 4;
   const cols = 8;
+  let gridEl;
+  const units = [];
+
+  const defaultSizes = {
+    cabinet: { w: 2, h: 3 },
+    drawer: { w: 1, h: 1 },
+    shelf: { w: 2, h: 1 }
+  };
 
   function createGridCell() {
     const cell = document.createElement('div');
@@ -15,17 +23,63 @@
     const grid = document.createElement('div');
     grid.id = 'kitchen-grid';
     grid.className = 'kitchen-grid';
+    grid.style.position = 'relative';
 
     for (let i = 0; i < rows * cols; i++) {
       grid.appendChild(createGridCell());
     }
 
     root.appendChild(grid);
+    gridEl = grid;
   }
 
+  function computeMetrics() {
+    if (!gridEl) return { width: 0, height: 0, gap: 0 };
+    const cell = gridEl.querySelector('.grid-cell');
+    if (!cell) return { width: 0, height: 0, gap: 0 };
+    const rect = cell.getBoundingClientRect();
+    const styles = window.getComputedStyle(gridEl);
+    const gap = parseInt(styles.gap) || 0;
+    return { width: rect.width, height: rect.height, gap };
+  }
+
+  function createUnitElement(type) {
+    const el = document.createElement('div');
+    el.className = `unit ${type}`;
+    el.textContent = type.charAt(0).toUpperCase() + type.slice(1);
+    return el;
+  }
+
+  function placeUnit(el, col, row, w, h) {
+    const { width, height, gap } = computeMetrics();
+    el.style.left = col * (width + gap) + 'px';
+    el.style.top = row * (height + gap) + 'px';
+    el.style.width = w * width + gap * (w - 1) + 'px';
+    el.style.height = h * height + gap * (h - 1) + 'px';
+  }
+
+  function addUnit(type) {
+    if (!gridEl || !defaultSizes[type]) return;
+    const size = defaultSizes[type];
+    const el = createUnitElement(type);
+    placeUnit(el, 0, 0, size.w, size.h);
+    gridEl.appendChild(el);
+    units.push({ type, el, col: 0, row: 0, w: size.w, h: size.h });
+  }
+
+  function onResize() {
+    units.forEach(u => placeUnit(u.el, u.col, u.row, u.w, u.h));
+  }
+
+  window.GridUnitManager = { addUnit };
+
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', renderGrid);
+    document.addEventListener('DOMContentLoaded', () => {
+      renderGrid();
+      window.addEventListener('resize', onResize);
+    });
   } else {
     renderGrid();
+    window.addEventListener('resize', onResize);
   }
 })();

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,19 @@
+(function() {
+  function setupToolbar() {
+    const toolbar = document.getElementById('unit-toolbar');
+    if (!toolbar || !window.GridUnitManager) return;
+
+    toolbar.addEventListener('click', (e) => {
+      const type = e.target.getAttribute('data-unit');
+      if (type) {
+        window.GridUnitManager.addUnit(type);
+      }
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', setupToolbar);
+  } else {
+    setupToolbar();
+  }
+})();


### PR DESCRIPTION
## Summary
- add toolbar with buttons to create Cabinet, Drawer, Shelf
- style toolbar and units
- implement basic GridUnitManager with addUnit logic and resizing
- wire toolbar buttons to add units

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686b89524a1c832b9b9282f77bdd862a