### PR TITLE
Add drag & resize functionality to kitchen units

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,29 @@ No external network calls; suitable for full offline use.
 
 ---
 
+## Agent: DragResizeHandler
+
+**Purpose**
+Enables dragging and resizing of storage units on the grid while snapping to cell boundaries.
+
+**Inputs**
+- DOM elements representing units
+- Pointer drag and resize events
+
+**Outputs**
+- Updated unit position and size via `GridUnitManager`
+
+**Core Logic**
+Uses a drag-and-drop library to map pointer movement to grid coordinates, clamping values so units remain within the grid.
+
+**Dependencies**
+Relies on `GridUnitManager` for dimension metrics and state updates.
+
+**Notes**
+Provides visual feedback during interaction; no external services used.
+
+---
+
 ## Planned Agents
 
 | Agent | Rationale | Status |

--- a/index.html
+++ b/index.html
@@ -17,7 +17,9 @@
 
   <div id="grid-root"></div>
 
+  <script src="https://cdn.jsdelivr.net/npm/interactjs/dist/interact.min.js"></script>
   <script src="js/main.js" defer></script>
   <script src="js/grid.js" defer></script>
+  <script src="js/dnd.js" defer></script>
 </body>
 </html>

--- a/js/dnd.js
+++ b/js/dnd.js
@@ -1,0 +1,36 @@
+(function() {
+  if (typeof interact === 'undefined' || !window.GridUnitManager) return;
+
+  function enableUnit(el) {
+    interact(el)
+      .draggable({ listeners: { move: onDragMove } })
+      .resizable({ edges: { left: true, right: true, bottom: true, top: true },
+                   listeners: { move: onResizeMove } });
+  }
+
+  function getCoords(event) {
+    const grid = document.getElementById('kitchen-grid');
+    const rect = grid.getBoundingClientRect();
+    const metrics = window.GridUnitManager.getMetrics();
+    const x = event.client.x - rect.left;
+    const y = event.client.y - rect.top;
+    return {
+      col: Math.round(x / (metrics.width + metrics.gap)),
+      row: Math.round(y / (metrics.height + metrics.gap))
+    };
+  }
+
+  function onDragMove(event) {
+    const { col, row } = getCoords(event);
+    window.GridUnitManager.moveUnit(event.target, col, row);
+  }
+
+  function onResizeMove(event) {
+    const metrics = window.GridUnitManager.getMetrics();
+    const w = Math.round(event.rect.width / (metrics.width + metrics.gap));
+    const h = Math.round(event.rect.height / (metrics.height + metrics.gap));
+    window.GridUnitManager.resizeUnit(event.target, w, h);
+  }
+
+  window.DragResize = { enableUnit };
+})();

--- a/js/grid.js
+++ b/js/grid.js
@@ -58,20 +58,58 @@
     el.style.height = h * height + gap * (h - 1) + 'px';
   }
 
+  function findUnit(el) {
+    return units.find(u => u.el === el);
+  }
+
+  function moveUnit(el, col, row) {
+    const u = findUnit(el);
+    if (!u) return;
+    col = Math.max(0, Math.min(cols - u.w, col));
+    row = Math.max(0, Math.min(rows - u.h, row));
+    u.col = col;
+    u.row = row;
+    placeUnit(u.el, u.col, u.row, u.w, u.h);
+  }
+
+  function resizeUnit(el, w, h) {
+    const u = findUnit(el);
+    if (!u) return;
+    w = Math.max(1, Math.min(cols - u.col, w));
+    h = Math.max(1, Math.min(rows - u.row, h));
+    u.w = w;
+    u.h = h;
+    placeUnit(u.el, u.col, u.row, u.w, u.h);
+  }
+
+  function getMetrics() {
+    return computeMetrics();
+  }
+
   function addUnit(type) {
     if (!gridEl || !defaultSizes[type]) return;
     const size = defaultSizes[type];
     const el = createUnitElement(type);
     placeUnit(el, 0, 0, size.w, size.h);
     gridEl.appendChild(el);
-    units.push({ type, el, col: 0, row: 0, w: size.w, h: size.h });
+    const unit = { type, el, col: 0, row: 0, w: size.w, h: size.h };
+    units.push(unit);
+    el.dataset.unitIndex = units.length - 1;
+    if (window.DragResize && window.DragResize.enableUnit) {
+      window.DragResize.enableUnit(el);
+    }
   }
 
   function onResize() {
     units.forEach(u => placeUnit(u.el, u.col, u.row, u.w, u.h));
   }
 
-  window.GridUnitManager = { addUnit };
+  window.GridUnitManager = {
+    addUnit,
+    moveUnit,
+    resizeUnit,
+    getMetrics
+  };
 
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- enable interact.js-powered dragging and resizing
- support grid snapping and clamping in `GridUnitManager`
- load interact.js and new `dnd.js`
- document the new `DragResizeHandler` agent

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686b8aade348832b89eeaac00da30dd3