### PR TITLE
Fix touch drag & resize for kitchen grid

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,8 @@ Uses a drag-and-drop library to map pointer movement to grid coordinates, clampi
 Relies on `GridUnitManager` for dimension metrics and state updates.
 
 **Notes**
-Provides visual feedback during interaction; no external services used.
+Provides visual feedback during interaction for both mouse and touch input;
+includes a visible resize handle element. No external services used.
 
 ---
 

--- a/css/style.css
+++ b/css/style.css
@@ -34,6 +34,18 @@
   align-items: center;
   justify-content: center;
   box-sizing: border-box;
+  touch-action: none;
+}
+
+.unit .resize-handle {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  right: -7px;
+  bottom: -7px;
+  background: #fff;
+  border: 2px solid #333;
+  border-radius: 50%;
 }
 
 .unit.cabinet {

--- a/js/dnd.js
+++ b/js/dnd.js
@@ -12,12 +12,22 @@
     const grid = document.getElementById('kitchen-grid');
     const rect = grid.getBoundingClientRect();
     const metrics = window.GridUnitManager.getMetrics();
-    const x = event.client.x - rect.left;
-    const y = event.client.y - rect.top;
+    const point = pointerCoords(event);
+    const x = point.x - rect.left;
+    const y = point.y - rect.top;
     return {
       col: Math.round(x / (metrics.width + metrics.gap)),
       row: Math.round(y / (metrics.height + metrics.gap))
     };
+  }
+
+  function pointerCoords(e) {
+    if (e.client) return { x: e.client.x, y: e.client.y };
+    if (typeof e.clientX === 'number') return { x: e.clientX, y: e.clientY };
+    if (e.touches && e.touches[0]) {
+      return { x: e.touches[0].clientX, y: e.touches[0].clientY };
+    }
+    return { x: 0, y: 0 };
   }
 
   function onDragMove(event) {

--- a/js/grid.js
+++ b/js/grid.js
@@ -47,6 +47,9 @@
     const el = document.createElement('div');
     el.className = `unit ${type}`;
     el.textContent = type.charAt(0).toUpperCase() + type.slice(1);
+    const handle = document.createElement('div');
+    handle.className = 'resize-handle';
+    el.appendChild(handle);
     return el;
   }
 


### PR DESCRIPTION
## Summary
- support touch interactions for drag/resize
- show visible resize handle for units
- document DragResizeHandler touch support

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686b8cc759c0832b947a112b18b3637f