### PR TITLE
Add splash screen and cohesive styling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,30 @@ includes a visible resize handle element. No external services used.
 
 ---
 
+## Agent: SplashScreen
+
+**Purpose**
+Displays an introductory splash screen with basic instructions and a button to begin sorting.
+
+**Inputs**
+- `localStorage` flag `splashSeen`
+- User clicks on the "Start Sorting" button
+- User toggles the "How to use this app" panel
+
+**Outputs**
+- Visibility toggle for the splash screen and main interface
+
+**Core Logic**
+Shows the splash screen on first load or until dismissed, then remembers the choice in `localStorage`.
+
+**Dependencies**
+Browser `localStorage` only.
+
+**Notes**
+Keep the instruction text accurate with the features that are actually available in the app. Future bug reports will be filed if the splash screen instructions fall out of sync with implemented functionality.
+
+---
+
 ## Planned Agents
 
 | Agent | Rationale | Status |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # start-sorting
 Kitchen Sorter is a simple, visual tool to organise your kitchen layout. Quickly design your kitchen’s grid and place appliances, utensils, and items into cabinets, drawers, and shelves to keep track of where everything goes.
 
-The main page now includes a responsive 8×4 grid that displays layout slots for your units.
+When you first load the application you’ll see a splash screen introducing the tool and describing the basic controls.
+Click **Start Sorting** to open the layout editor.
+The main page then shows a responsive 8×4 grid that displays layout slots for your units.

--- a/css/style.css
+++ b/css/style.css
@@ -1,3 +1,55 @@
+
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  background-color: #f7f5f2;
+  color: #333;
+}
+
+h1 {
+  color: #2a726a;
+  text-align: center;
+}
+
+.primary-btn {
+  background-color: #2a726a;
+  color: #fff;
+  border: none;
+  padding: 10px 20px;
+  cursor: pointer;
+}
+
+.primary-btn:hover {
+  background-color: #245c55;
+}
+
+.splash-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  text-align: center;
+  padding: 20px;
+}
+
+.instructions {
+  margin: 20px 0;
+  max-width: 400px;
+}
+
+.collapse {
+  display: none;
+}
+
+.collapse.open {
+  display: block;
+}
+
+#app {
+  padding: 20px;
+}
+
 .kitchen-grid {
   display: grid;
   grid-template-columns: repeat(8, 1fr);
@@ -9,20 +61,30 @@
 }
 
 .kitchen-grid .grid-cell {
-  border: 1px solid #e0e0e0;
-  background-color: #f8f8f8;
+  border: 1px solid #cfd8d6;
+  background-color: #eef1f0;
   min-height: 50px;
   box-sizing: border-box;
 }
+
 
 .toolbar {
   text-align: center;
   margin: 10px 0;
 }
 
+
 .toolbar button {
   margin-right: 6px;
   padding: 6px 12px;
+  border: none;
+  background-color: #2a726a;
+  color: #fff;
+  cursor: pointer;
+}
+
+.toolbar button:hover {
+  background-color: #245c55;
 }
 
 .unit {
@@ -48,14 +110,17 @@
   border-radius: 50%;
 }
 
+
 .unit.cabinet {
-  background-color: #8b4513;
+  background-color: #6b4f2a;
 }
+
 
 .unit.drawer {
-  background-color: #708090;
+  background-color: #5f6a7d;
 }
 
+
 .unit.shelf {
-  background-color: #228b22;
+  background-color: #3f8a4b;
 }

--- a/index.html
+++ b/index.html
@@ -7,17 +7,31 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-  <h1>Kitchen Sorter</h1>
-
-  <div id="unit-toolbar" class="toolbar">
-    <button data-unit="cabinet">Cabinet</button>
-    <button data-unit="drawer">Drawer</button>
-    <button data-unit="shelf">Shelf</button>
+  <div id="splash-screen" class="splash-screen">
+    <h1>Kitchen Sorter</h1>
+    <div class="instructions">
+      <button id="toggle-instructions" class="primary-btn">How to use this app</button>
+      <div id="instruction-content" class="collapse">
+        <p>Use the toolbar to add cabinets, drawers and shelves to the grid. Drag each unit to reposition it and use the handle to resize.</p>
+      </div>
+    </div>
+    <button id="start-btn" class="primary-btn">Start Sorting</button>
   </div>
 
-  <div id="grid-root"></div>
+  <div id="app" style="display: none;">
+    <h1>Kitchen Sorter</h1>
+
+    <div id="unit-toolbar" class="toolbar">
+      <button data-unit="cabinet">Cabinet</button>
+      <button data-unit="drawer">Drawer</button>
+      <button data-unit="shelf">Shelf</button>
+    </div>
+
+    <div id="grid-root"></div>
+  </div>
 
   <script src="https://cdn.jsdelivr.net/npm/interactjs/dist/interact.min.js"></script>
+  <script src="js/splash.js" defer></script>
   <script src="js/main.js" defer></script>
   <script src="js/grid.js" defer></script>
   <script src="js/dnd.js" defer></script>

--- a/js/splash.js
+++ b/js/splash.js
@@ -1,0 +1,33 @@
+(function() {
+  function setupSplash() {
+    const splash = document.getElementById('splash-screen');
+    const app = document.getElementById('app');
+    const startBtn = document.getElementById('start-btn');
+    const toggleBtn = document.getElementById('toggle-instructions');
+    const instructions = document.getElementById('instruction-content');
+    if (!splash || !app || !startBtn) return;
+
+    if (localStorage.getItem('splashSeen')) {
+      splash.style.display = 'none';
+      app.style.display = '';
+    }
+
+    startBtn.addEventListener('click', () => {
+      splash.style.display = 'none';
+      app.style.display = '';
+      localStorage.setItem('splashSeen', 'true');
+    });
+
+    if (toggleBtn && instructions) {
+      toggleBtn.addEventListener('click', () => {
+        instructions.classList.toggle('open');
+      });
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', setupSplash);
+  } else {
+    setupSplash();
+  }
+})();


### PR DESCRIPTION
## Summary
- refresh styling with muted teal colour palette
- implement splash screen with collapsible instructions
- show editor after **Start Sorting** is clicked and remember preference in localStorage
- describe new splash screen in README
- document `SplashScreen` agent in AGENTS.md

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686b8e115bdc832bb48aaa928a872e52