### PR TITLE
Fix touch interactions for grid units

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -97,6 +97,14 @@ h1 {
   justify-content: center;
   box-sizing: border-box;
   touch-action: none;
+  -ms-touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.unit * {
+  touch-action: none;
+  -ms-touch-action: none;
 }
 
 .unit .resize-handle {

--- a/js/dnd.js
+++ b/js/dnd.js
@@ -3,9 +3,9 @@
 
   function enableUnit(el) {
     interact(el)
-      .draggable({ listeners: { move: onDragMove } })
+      .draggable({ listeners: { start: preventDefault, move: onDragMove } })
       .resizable({ edges: { left: true, right: true, bottom: true, top: true },
-                   listeners: { move: onResizeMove } });
+                   listeners: { start: preventDefault, move: onResizeMove } });
   }
 
   function getCoords(event) {
@@ -28,6 +28,12 @@
       return { x: e.touches[0].clientX, y: e.touches[0].clientY };
     }
     return { x: 0, y: 0 };
+  }
+
+  function preventDefault(event) {
+    if (event && typeof event.preventDefault === 'function') {
+      event.preventDefault();
+    }
   }
 
   function onDragMove(event) {


### PR DESCRIPTION
## Summary
- add non-selectable style and touch-action fixes for unit elements
- call `preventDefault` on touch gestures when dragging or resizing

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686b8f17af54832b84ac3af2d90be7b1