### PR TITLE
Add draggable item palette sidebar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -132,3 +132,81 @@ h1 {
 .unit.shelf {
   background-color: #3f8a4b;
 }
+
+.main-layout {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+#grid-root {
+  flex: 1;
+  position: relative;
+}
+
+.item-sidebar {
+  width: 200px;
+  background-color: #eef1f0;
+  border-right: 1px solid #cfd8d6;
+  padding: 10px;
+  box-sizing: border-box;
+}
+
+.item-sidebar h2 {
+  margin-top: 0;
+  color: #2a726a;
+}
+
+.item-sidebar input {
+  width: 100%;
+  margin-bottom: 8px;
+  padding: 4px;
+  box-sizing: border-box;
+}
+
+.item-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.item-entry {
+  display: flex;
+  align-items: center;
+  background-color: #fff;
+  border: 1px solid #cfd8d6;
+  padding: 4px;
+  margin-bottom: 6px;
+  cursor: grab;
+}
+
+.item-entry:active {
+  cursor: grabbing;
+}
+
+.item-label {
+  flex-grow: 1;
+}
+
+.item-count {
+  background-color: #2a726a;
+  color: #fff;
+  border-radius: 10px;
+  padding: 2px 6px;
+  font-size: 0.8em;
+  margin-left: 4px;
+}
+
+.qty-btn {
+  background-color: #2a726a;
+  color: #fff;
+  border: none;
+  width: 20px;
+  height: 20px;
+  margin-left: 4px;
+  cursor: pointer;
+}
+
+.qty-btn:hover {
+  background-color: #245c55;
+}

--- a/index.html
+++ b/index.html
@@ -27,7 +27,14 @@
       <button data-unit="shelf">Shelf</button>
     </div>
 
-    <div id="grid-root"></div>
+    <div id="main-layout" class="main-layout">
+      <div id="item-sidebar" class="item-sidebar">
+        <h2>Items</h2>
+        <input id="new-item-input" type="text" placeholder="Add item" />
+        <ul id="item-list"></ul>
+      </div>
+      <div id="grid-root"></div>
+    </div>
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/interactjs/dist/interact.min.js"></script>
@@ -35,5 +42,6 @@
   <script src="js/main.js" defer></script>
   <script src="js/grid.js" defer></script>
   <script src="js/dnd.js" defer></script>
+  <script src="js/inventory.js" defer></script>
 </body>
 </html>

--- a/js/grid.js
+++ b/js/grid.js
@@ -43,6 +43,15 @@
     return { width: rect.width, height: rect.height, gap };
   }
 
+  function onItemDrop(e) {
+    e.preventDefault();
+    if (!window.InventoryPalette) return;
+    const id = e.dataTransfer.getData('text/plain');
+    if (id) {
+      window.InventoryPalette.placeItem(id, e.currentTarget);
+    }
+  }
+
   function createUnitElement(type) {
     const el = document.createElement('div');
     el.className = `unit ${type}`;
@@ -50,6 +59,8 @@
     const handle = document.createElement('div');
     handle.className = 'resize-handle';
     el.appendChild(handle);
+    el.addEventListener('dragover', (e) => e.preventDefault());
+    el.addEventListener('drop', onItemDrop);
     return el;
   }
 

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1,0 +1,111 @@
+(function() {
+  const items = {};
+  const listEl = document.getElementById('item-list');
+  const inputEl = document.getElementById('new-item-input');
+
+  function normalize(name) {
+    return name.trim().toLowerCase();
+  }
+
+  function remaining(item) {
+    return item.total - item.placed.length;
+  }
+
+  function addItem(name) {
+    const id = normalize(name);
+    if (!id) return;
+    if (items[id]) {
+      items[id].total += 1;
+    } else {
+      items[id] = { name: name.trim(), total: 1, placed: [] };
+    }
+    render();
+  }
+
+  function changeQuantity(id, delta) {
+    const item = items[id];
+    if (!item) return;
+    const min = item.placed.length;
+    item.total = Math.max(min, item.total + delta);
+    render();
+  }
+
+  function placeItem(id, unitEl) {
+    const item = items[id];
+    if (!item) return false;
+    if (remaining(item) <= 0) return false;
+    item.placed.push(unitEl);
+    render();
+    return true;
+  }
+
+  function onInputKey(e) {
+    if (e.key === 'Enter') {
+      addItem(inputEl.value);
+      inputEl.value = '';
+    }
+  }
+
+  function createEntry(id, item) {
+    const li = document.createElement('li');
+    li.className = 'item-entry';
+    li.draggable = true;
+    li.dataset.itemId = id;
+
+    const label = document.createElement('span');
+    label.className = 'item-label';
+    label.textContent = item.name;
+
+    const badge = document.createElement('span');
+    badge.className = 'item-count';
+    badge.textContent = remaining(item);
+
+    const inc = document.createElement('button');
+    inc.className = 'qty-btn';
+    inc.textContent = '＋';
+    inc.addEventListener('click', () => changeQuantity(id, 1));
+
+    const dec = document.createElement('button');
+    dec.className = 'qty-btn';
+    dec.textContent = '−';
+    dec.addEventListener('click', () => changeQuantity(id, -1));
+
+    li.appendChild(label);
+    li.appendChild(badge);
+    li.appendChild(inc);
+    li.appendChild(dec);
+
+    li.addEventListener('dragstart', (e) => {
+      e.dataTransfer.setData('text/plain', id);
+    });
+
+    return li;
+  }
+
+  function render() {
+    if (!listEl) return;
+    listEl.innerHTML = '';
+    Object.keys(items).forEach(id => {
+      listEl.appendChild(createEntry(id, items[id]));
+    });
+  }
+
+  function init() {
+    if (!listEl || !inputEl) return;
+    inputEl.addEventListener('keydown', onInputKey);
+    addItem('plates');
+    addItem('mugs');
+    addItem('mixer');
+  }
+
+  window.InventoryPalette = {
+    addItem,
+    placeItem
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Summary
- add professional-looking sidebar to manage kitchen items
- style sidebar and item list
- allow adding, adjusting and dragging items
- units accept item drops and trigger InventoryPalette

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686b9ff53f38832b8e61674578a76d04