### PR TITLE
Implement item placement with home navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,8 @@ Keeps the catalogue of items (plates, mixer, bread knife, etc.), tracks total co
 - Drop events from placement actions  
 - Optional manual count edits
 
-**Outputs**  
-- `items` map with `total` and `placed[]` arrays  
+**Outputs**
+- `items` map with `total` and `placed[]` arrays
 - Badge updates reflecting remaining quantity
 
 **Core Logic**  
@@ -52,8 +52,9 @@ Decrements totals on placement, prevents negative counts, and re-increments on i
 **Dependencies**  
 Relies on `GridUnitManager` events to stay in sync.
 
-**Notes**  
-Free-text item names; duplicates are merged case-insensitively.
+**Notes**
+Free-text item names; duplicates are merged case-insensitively. When a count
+drops to zero the palette entry is disabled until quantity increases.
 
 ---
 
@@ -76,8 +77,10 @@ Single responsibility layer that mediates between UI drag-and-drop and state mut
 **Dependencies**  
 Receives grid and item maps from `GridUnitManager` and `InventoryPalette`.
 
-**Notes**  
+**Notes**
 If an item has already reached its total count, further drops are blocked.
+The view layer shows the placed item name inside the unit when placement
+is successful.
 
 ---
 
@@ -171,6 +174,28 @@ Browser `localStorage` only.
 
 **Notes**
 Keep the instruction text accurate with the features that are actually available in the app. Future bug reports will be filed if the splash screen instructions fall out of sync with implemented functionality.
+
+---
+
+## Agent: HomeButton
+
+**Purpose**
+Provides a persistent navigation control to return to the splash screen.
+
+**Inputs**
+- User taps the home icon
+
+**Outputs**
+- Toggles visibility of the main interface and splash screen
+
+**Core Logic**
+Simple click handler that hides `#app`, shows `#splash-screen`, and hides itself.
+
+**Dependencies**
+Browser `localStorage` only.
+
+**Notes**
+Visible on every screen except the splash screen.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ Kitchen Sorter is a simple, visual tool to organise your kitchen layout. Quickly
 
 When you first load the application you’ll see a splash screen introducing the tool and describing the basic controls.
 Click **Start Sorting** to open the layout editor.
-The main page then shows a responsive 8×4 grid that displays layout slots for your units.
+The main page then shows a responsive 8×4 grid that displays layout slots for your units. Use the item sidebar to add items and drag them onto units; each placement lowers the available count and lists the item inside the unit. Use the home button in the corner to return to the splash screen at any time.

--- a/css/style.css
+++ b/css/style.css
@@ -210,3 +210,36 @@ h1 {
 .qty-btn:hover {
   background-color: #245c55;
 }
+
+.item-entry.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.unit-items {
+  position: absolute;
+  bottom: 2px;
+  left: 2px;
+  right: 2px;
+  font-size: 0.6em;
+  color: #fff;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  text-align: left;
+}
+
+.home-btn {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  background: #2a726a;
+  color: #fff;
+  border: none;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+
+.home-btn:hover {
+  background: #245c55;
+}

--- a/index.html
+++ b/index.html
@@ -12,13 +12,14 @@
     <div class="instructions">
       <button id="toggle-instructions" class="primary-btn">How to use this app</button>
       <div id="instruction-content" class="collapse">
-        <p>Use the toolbar to add cabinets, drawers and shelves to the grid. Drag each unit to reposition it and use the handle to resize.</p>
+        <p>Use the toolbar to add cabinets, drawers and shelves to the grid. Drag each unit to reposition it and use the handle to resize. Add items in the sidebar and drop them onto your units. Tap the home button to return here any time.</p>
       </div>
     </div>
     <button id="start-btn" class="primary-btn">Start Sorting</button>
   </div>
 
   <div id="app" style="display: none;">
+    <button id="home-btn" class="home-btn" style="display:none;">🏠</button>
     <h1>Kitchen Sorter</h1>
 
     <div id="unit-toolbar" class="toolbar">
@@ -43,5 +44,6 @@
   <script src="js/grid.js" defer></script>
   <script src="js/dnd.js" defer></script>
   <script src="js/inventory.js" defer></script>
+  <script src="js/placement.js" defer></script>
 </body>
 </html>

--- a/js/grid.js
+++ b/js/grid.js
@@ -45,17 +45,23 @@
 
   function onItemDrop(e) {
     e.preventDefault();
-    if (!window.InventoryPalette) return;
+    if (!window.PlacementAssigner) return;
     const id = e.dataTransfer.getData('text/plain');
     if (id) {
-      window.InventoryPalette.placeItem(id, e.currentTarget);
+      window.PlacementAssigner.assign(id, e.currentTarget);
     }
   }
 
   function createUnitElement(type) {
     const el = document.createElement('div');
     el.className = `unit ${type}`;
-    el.textContent = type.charAt(0).toUpperCase() + type.slice(1);
+    const label = document.createElement('span');
+    label.className = 'unit-label';
+    label.textContent = type.charAt(0).toUpperCase() + type.slice(1);
+    el.appendChild(label);
+    const items = document.createElement('ul');
+    items.className = 'unit-items';
+    el.appendChild(items);
     const handle = document.createElement('div');
     handle.className = 'resize-handle';
     el.appendChild(handle);

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -30,14 +30,19 @@
     render();
   }
 
-  function placeItem(id, unitEl) {
-    const item = items[id];
-    if (!item) return false;
-    if (remaining(item) <= 0) return false;
-    item.placed.push(unitEl);
-    render();
-    return true;
-  }
+    function placeItem(id, unitEl) {
+      const item = items[id];
+      if (!item) return false;
+      if (remaining(item) <= 0) return false;
+      const unitId = unitEl.dataset.unitIndex;
+      item.placed.push(unitId);
+      render();
+      return true;
+    }
+
+    function getItem(id) {
+      return items[id];
+    }
 
   function onInputKey(e) {
     if (e.key === 'Enter') {
@@ -49,7 +54,8 @@
   function createEntry(id, item) {
     const li = document.createElement('li');
     li.className = 'item-entry';
-    li.draggable = true;
+    li.draggable = remaining(item) > 0;
+    if (!li.draggable) li.classList.add('disabled');
     li.dataset.itemId = id;
 
     const label = document.createElement('span');
@@ -76,6 +82,10 @@
     li.appendChild(dec);
 
     li.addEventListener('dragstart', (e) => {
+      if (remaining(item) <= 0) {
+        e.preventDefault();
+        return;
+      }
       e.dataTransfer.setData('text/plain', id);
     });
 
@@ -100,7 +110,8 @@
 
   window.InventoryPalette = {
     addItem,
-    placeItem
+    placeItem,
+    getItem
   };
 
   if (document.readyState === 'loading') {

--- a/js/placement.js
+++ b/js/placement.js
@@ -1,0 +1,29 @@
+(function() {
+  function assign(itemId, unitEl) {
+    if (!window.InventoryPalette) return false;
+    const success = window.InventoryPalette.placeItem(itemId, unitEl);
+    if (success) {
+      renderIntoUnit(itemId, unitEl);
+    }
+    return success;
+  }
+
+  function renderIntoUnit(itemId, unitEl) {
+    const item = window.InventoryPalette.getItem(itemId);
+    if (!item) return;
+    let list = unitEl.querySelector('.unit-items');
+    if (!list) {
+      list = document.createElement('ul');
+      list.className = 'unit-items';
+      unitEl.appendChild(list);
+    }
+    const li = document.createElement('li');
+    li.textContent = item.name;
+    list.appendChild(li);
+  }
+
+  window.PlacementAssigner = {
+    assign
+  };
+})();
+

--- a/js/splash.js
+++ b/js/splash.js
@@ -1,22 +1,33 @@
 (function() {
-  function setupSplash() {
-    const splash = document.getElementById('splash-screen');
-    const app = document.getElementById('app');
-    const startBtn = document.getElementById('start-btn');
-    const toggleBtn = document.getElementById('toggle-instructions');
-    const instructions = document.getElementById('instruction-content');
-    if (!splash || !app || !startBtn) return;
+    function setupSplash() {
+      const splash = document.getElementById('splash-screen');
+      const app = document.getElementById('app');
+      const startBtn = document.getElementById('start-btn');
+      const toggleBtn = document.getElementById('toggle-instructions');
+      const instructions = document.getElementById('instruction-content');
+      const homeBtn = document.getElementById('home-btn');
+      if (!splash || !app || !startBtn) return;
 
-    if (localStorage.getItem('splashSeen')) {
-      splash.style.display = 'none';
-      app.style.display = '';
-    }
+      if (localStorage.getItem('splashSeen')) {
+        splash.style.display = 'none';
+        app.style.display = '';
+        if (homeBtn) homeBtn.style.display = 'block';
+      }
 
-    startBtn.addEventListener('click', () => {
-      splash.style.display = 'none';
-      app.style.display = '';
-      localStorage.setItem('splashSeen', 'true');
-    });
+      startBtn.addEventListener('click', () => {
+        splash.style.display = 'none';
+        app.style.display = '';
+        localStorage.setItem('splashSeen', 'true');
+        if (homeBtn) homeBtn.style.display = 'block';
+      });
+
+      if (homeBtn) {
+        homeBtn.addEventListener('click', () => {
+          app.style.display = 'none';
+          splash.style.display = '';
+          homeBtn.style.display = 'none';
+        });
+      }
 
     if (toggleBtn && instructions) {
       toggleBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- allow adding items to units and show them in the unit
- disable dragging items when out of stock
- add persistent home button to return to splash screen
- update splash instructions about items and home button
- document new HomeButton agent

## Testing
- `node --check js/main.js`
- `node --check js/grid.js`
- `node --check js/dnd.js`
- `node --check js/inventory.js`
- `node --check js/splash.js`
- `node --check js/placement.js`


------
https://chatgpt.com/codex/tasks/task_e_686ba2cb5404832b84b35d612354a362