### PR TITLE
Add worktop unit support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,9 @@ Applies snap-to-grid arithmetic and prevents overlap through simple collision ch
 **Dependencies**  
 None beyond in-browser state.
 
-**Notes**  
+**Notes**
 Abstract sizes only; no real-world measurements.
+Default unit sizes: cabinet 2×3, drawer 1×1, shelf 2×1, worktop 4×1.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # start-sorting
-Kitchen Sorter is a simple, visual tool to organise your kitchen layout. Quickly design your kitchen’s grid and place appliances, utensils, and items into cabinets, drawers, and shelves to keep track of where everything goes.
+Kitchen Sorter is a simple, visual tool to organise your kitchen layout. Quickly design your kitchen’s grid and place appliances, utensils, and items into cabinets, drawers, shelves and worktops to keep track of where everything goes.
 
 When you first load the application you’ll see a splash screen introducing the tool and describing the basic controls.
 Click **Start Sorting** to open the layout editor.

--- a/css/style.css
+++ b/css/style.css
@@ -133,6 +133,10 @@ h1 {
   background-color: #3f8a4b;
 }
 
+.unit.worktop {
+  background-color: #9b774f;
+}
+
 .main-layout {
   display: flex;
   align-items: flex-start;

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <div class="instructions">
       <button id="toggle-instructions" class="primary-btn">How to use this app</button>
       <div id="instruction-content" class="collapse">
-        <p>Use the toolbar to add cabinets, drawers and shelves to the grid. Drag each unit to reposition it and use the handle to resize. Add items in the sidebar and drop them onto your units. Tap the home button to return here any time.</p>
+        <p>Use the toolbar to add cabinets, drawers, shelves and worktops to the grid. Drag each unit to reposition it and use the handle to resize. Add items in the sidebar and drop them onto your units. Tap the home button to return here any time.</p>
       </div>
     </div>
     <button id="start-btn" class="primary-btn">Start Sorting</button>
@@ -26,6 +26,7 @@
       <button data-unit="cabinet">Cabinet</button>
       <button data-unit="drawer">Drawer</button>
       <button data-unit="shelf">Shelf</button>
+      <button data-unit="worktop">Worktop</button>
     </div>
 
     <div id="main-layout" class="main-layout">

--- a/js/grid.js
+++ b/js/grid.js
@@ -7,7 +7,8 @@
   const defaultSizes = {
     cabinet: { w: 2, h: 3 },
     drawer: { w: 1, h: 1 },
-    shelf: { w: 2, h: 1 }
+    shelf: { w: 2, h: 1 },
+    worktop: { w: 4, h: 1 }
   };
 
   function createGridCell() {


### PR DESCRIPTION
## Summary
- include Worktop button in the unit toolbar
- style worktops and define default size
- document worktops in splash instructions, README and AGENTS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686cd69a9e48832b8b9b3104a500a6cf